### PR TITLE
Category and search filters for boards

### DIFF
--- a/server/api-docs/boards.http
+++ b/server/api-docs/boards.http
@@ -12,18 +12,50 @@ GET http://localhost:3001/api/boards
 
 ###
 
-### Get All Boards by Category (celebration)
-GET http://localhost:3001/api/boards?category=celebration
+### Get All Boards by Category
+GET http://localhost:3001/api/boards?category={category name}
 
 ###
 
-### Get All Boards by Category (thank you)
-GET http://localhost:3001/api/boards?category=thank%20you
+### Get Recent Boards (6 most recently created)
+GET http://localhost:3001/api/boards?category=recent
 
 ###
 
-### Get All Boards by Category (inspiration)
-GET http://localhost:3001/api/boards?category=inspiration
+### Get Multiple Categories
+GET http://localhost:3001/api/boards?category=celebration,thank%20you
+
+###
+
+### Get Multiple Categories with Recent (returns 6 most recent from selected categories)
+GET http://localhost:3001/api/boards?category=celebration,inspiration,recent
+
+###
+
+### Search Boards by Title
+GET http://localhost:3001/api/boards?search=team
+
+###
+
+### Search Boards by Title with Single Category Filter
+GET http://localhost:3001/api/boards?category=celebration&search=team
+
+###
+
+### Search Boards by Title with Multiple Categories
+GET http://localhost:3001/api/boards?category=celebration,thank%20you&search=team
+
+###
+
+### Search Recent Boards by Title
+GET http://localhost:3001/api/boards?category=recent&search=celebration
+
+###
+
+### Search Multiple Categories with Recent (returns 6 most recent matching search)
+GET http://localhost:3001/api/boards?category=celebration,inspiration,recent&search=team
+
+###
 
 ###
 

--- a/server/constants.js
+++ b/server/constants.js
@@ -1,3 +1,4 @@
 const validCategories = ['celebration', 'thank you', 'inspiration'];
+const recentLimit = 6;
 
-module.exports = { validCategories };
+module.exports = { validCategories, recentLimit };

--- a/server/src/controllers/boardController.js
+++ b/server/src/controllers/boardController.js
@@ -3,11 +3,10 @@ const boardService = require('../services/boardService');
 class BoardController {
 
     // GET /api/boards
-    async getAllBoards(req, res, next) {
+    async getBoards(req, res, next) {
         try {
-            const { category } = req.query;
-            const boards = await boardService.getAllBoards(category);
-
+            const { category, search } = req.query;
+            const boards = await boardService.getBoards(category, search);
             res.json(boards);
         } catch (error) {
             next(error); // passes error to error handle in middleware

--- a/server/src/routes/boardRoutes.js
+++ b/server/src/routes/boardRoutes.js
@@ -4,7 +4,7 @@ const boardController = require('../controllers/boardController');
 const { validateBoard } = require('../middleware/validators');
 
 // GET /api/boards - Get all boards
-router.get('/', boardController.getAllBoards);
+router.get('/', boardController.getBoards);
 
 // GET /api/boards/:id - Get board by id
 router.get('/:id', boardController.getBoardById);

--- a/server/src/services/boardService.js
+++ b/server/src/services/boardService.js
@@ -1,5 +1,5 @@
 const { PrismaClient } = require('../generated/prisma');
-const { resentLimit } = require('../../constants');
+const { recentLimit } = require('../../constants');
 const prisma = new PrismaClient();
 
 class BoardService {
@@ -83,7 +83,7 @@ class BoardService {
             }
 
             if (isRecent) {
-                limit = 6;
+                limit = recentLimit;
             }
         }
 

--- a/server/src/services/boardService.js
+++ b/server/src/services/boardService.js
@@ -1,11 +1,11 @@
 const { PrismaClient } = require('../generated/prisma');
+const { resentLimit } = require('../../constants');
 const prisma = new PrismaClient();
 
 class BoardService {
 
-    // get all boards with optional category filter
-    async getAllBoards(category) {
-        const filter = this.buildCategoryFilter(category);
+    async getBoards(categories, search) {
+        const { filter, limit } = this.buildFilter(categories, search);
 
         const boards = await prisma.board.findMany({
             where: filter,
@@ -13,6 +13,7 @@ class BoardService {
                 cards: true,
             },
             orderBy: { createdAt: 'desc' },
+            ...(limit && { take: limit }),
         });
 
         return boards;
@@ -59,13 +60,41 @@ class BoardService {
         return deletedBoard;
     }
 
-    buildCategoryFilter(category) {
-        // TODO: add filter for recent boards
-        if (category !== 'all'){
-            return { category: category };
-        }else{
-            return {};
+    buildFilter(categories, search) {
+        const filter = {};
+        let isRecent = false;
+        let limit = null;
+
+        if (categories) {
+            const categoryArray = categories.split(',').map(cat => cat.trim());
+
+            isRecent = categoryArray.includes('recent');
+
+            const validCategories = categoryArray.filter(cat =>
+                cat !== 'all' && cat !== 'recent'
+            );
+
+            if (validCategories.length > 0) {
+                if (validCategories.length === 1) {
+                    filter.category = validCategories[0];
+                } else {
+                    filter.category = { in: validCategories };
+                }
+            }
+
+            if (isRecent) {
+                limit = 6;
+            }
         }
+
+        if (search && search.trim()) {
+            filter.title = {
+                contains: search.trim(),
+                mode: 'insensitive'
+            };
+        }
+
+        return { filter, limit };
     }
 }
 


### PR DESCRIPTION
The changes in this PR are allow multiple category types to be included in the category query parameter so that users can select more than one category to be shown.

When 'recent' is in the query parameters, only the most recent 6 results are returned.

A search string can now be included in the query parameters and enables a search by title for boards.